### PR TITLE
updates tox.ini allowing posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ ignore_basepython_conflict = true
 [testenv]
 basepython =
     {py36}: {env:TOXPYTHON:python3.6}
-    {py37}: {env:TOXPYTHON:python3.7}
+    {py37,docs}: {env:TOXPYTHON:python3.7}
     {py38}: {env:TOXPYTHON:python3.8}
-    {check,radon,docs,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {check,radon,safety,codecov,coveralls}: {env:TOXPYTHON:python3}
 passenv = *
 #deps = -r{toxinidir}/cirequirements.txt
 
@@ -28,11 +28,12 @@ deps =
     pytest
     pytest-travis-fold
     pytest-cov
+    hypothesis
     coverage
 commands_pre =
     coverage erase
 commands =
-    {posargs:pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv tests}
+    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv --hypothesis-show-statistics {posargs}
 commands_post = 
     coverage report
     coverage html
@@ -70,7 +71,7 @@ commands =
     python --version
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
-    flake8 src tests setup.py docs
+    flake8 {posargs:src tests setup.py docs}
     isort --verbose --check-only --diff src tests setup.py
     bumpversion --dry-run --verbose --allow-dirty patch
     bumpversion --dry-run --verbose --allow-dirty minor
@@ -90,6 +91,13 @@ deps =
 commands =
     sphinx-build {posargs:-E} -b html docs/rst dist/docs
     #sphinx-build -b linkcheck docs dist/docs
+
+# this is separated because safety does not work on AppVeyor
+# - so far my knowledge (JMCT)
+[testenv:safety]
+deps = safety
+skip_install = true
+commands = safety check
 
 [testenv:codecov]
 depends = report
@@ -148,8 +156,10 @@ sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 #known_standard_library=std,std2
 known_first_party = sampleproject
 known_third_party = 
+    hypothesis
     matplotlib
     numpy
+    pytest
 
 [tool:pytest]
 # If a pytest section is found in one of the possible config files


### PR DESCRIPTION
* updates tox.ini allowing posargs
  ** example `tox -e py37 -- tests/test_dummy.py`
* moves `docs` in `tox` to `py37`.