### PR TITLE
Revert to have `pr` in `tox`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -28,11 +28,9 @@ search = version = release = '{current_version}'
 replace = version = release = '{new_version}'
 
 [bumpversion:file:docs/CHANGELOG.rst]
-search = 
-	Changelog
+search = Changelog
 	=========
-replace = 
-	Changelog
+replace = Changelog
 	=========
 	
 	v{new_version} ({now:%Y-%m-%d})

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+name: pr requirements
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install tox
+
+    - name: test docs
+      run: tox -e pr

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* revert to `pr` testenv in `tox`
+* Remove the empty line in changelog title
+
 v0.9.0 (2022-05-26)
 ------------------------------------------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     docs
     test
     lint
+    pr
 
 # configures which environments run with each python version
 # the current configuration has the 'test' enviroment. This will run the
@@ -17,7 +18,7 @@ envlist =
 # versions are installed
 [testenv]
 basepython =
-    {test,build,docs,lint,radon,safety}: {env:TOXPYTHON:python3}
+    {pr,test,build,docs,lint,radon,safety}: {env:TOXPYTHON:python3}
 passenv = *
 
 # configures the unittest environment for python 3.6
@@ -50,6 +51,14 @@ commands_post =
 # in previous verions, I had independent environments to manage the
 # coverage reports. However, I found that doing such as pre and post
 # commands facilitates many configuration details
+
+[testenv:pr]
+# these commands cannot be in the [testenv:build] because they will trigger
+# after the versionbump which commit has different characteristics of the PR
+skip_install = true
+commands =
+    python {toxinidir}/devtools/check_changelog.py
+
 
 # separates lint from build env
 [testenv:lint]
@@ -85,7 +94,6 @@ deps =
 commands_pre = python {toxinidir}/devtools/clean_dist_check.py
 commands =
     python --version
-    python {toxinidir}/devtools/check_changelog.py
     python setup.py sdist bdist_wheel
     twine check dist/*.whl
     twine check dist/*.tar.gz


### PR DESCRIPTION
In #20 we removed the `prreqs` testenv in `tox` by moving the `check_changelog.py` script to the `build` env. However, this raises an error (as expected) when the version bump and deploy action commits to master, because in the event there is not update of the `CHANGELOG` file.

Hence, we need the `pr` env.